### PR TITLE
Update pytest requirement from ~=7.4 to ~=8.1

### DIFF
--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -3,7 +3,7 @@
 astroid==3.1.0  # Pinned to a specific version for tests
 typing-extensions~=4.10
 py~=1.11.0
-pytest~=7.4
+pytest~=8.1
 pytest-benchmark~=4.0
 pytest-timeout~=2.2
 towncrier~=23.11


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pylint-dev/pylint#9483](https://togithub.com/pylint-dev/pylint/pull/9483).



The original branch is upstream/dependabot/pip/pytest-approx-eq-8.1