### PR TITLE
[Feature] Add filepaths checked to verbose msg

### DIFF
--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -356,6 +356,7 @@ class PyLinter(
         self.current_file: str | None = None
         self._ignore_file = False
         self._ignore_paths: list[Pattern[str]] = []
+        self._files_checked = set()
 
         self.register_checker(self)
 
@@ -750,6 +751,7 @@ class PyLinter(
                 continue
             try:
                 self._lint_file(fileitem, module, check_astroid_module)
+                self._files_checked.add(fileitem.filepath)
             except Exception as ex:  # pylint: disable=broad-except
                 template_path = prepare_crash_report(
                     ex, fileitem.filepath, self.crash_file_path
@@ -1142,7 +1144,8 @@ class PyLinter(
             if verbose:
                 checked_files_count = self.stats.node_count["module"]
                 unchecked_files_count = self.stats.undocumented["module"]
-                msg += f"\nChecked {checked_files_count} files, skipped {unchecked_files_count} files"
+                checked_files = ', '.join(self._files_checked)
+                msg += f"\nChecked {checked_files_count} files ({checked_files}), skipped {unchecked_files_count} files"
 
         if self.config.score:
             sect = report_nodes.EvaluationSection(msg)

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -356,7 +356,6 @@ class PyLinter(
         self.current_file: str | None = None
         self._ignore_file = False
         self._ignore_paths: list[Pattern[str]] = []
-        self._files_checked = set()
 
         self.register_checker(self)
 
@@ -751,7 +750,7 @@ class PyLinter(
                 continue
             try:
                 self._lint_file(fileitem, module, check_astroid_module)
-                self._files_checked.add(fileitem.filepath)
+                self.stats.modules_names.add(fileitem.filepath)
             except Exception as ex:  # pylint: disable=broad-except
                 template_path = prepare_crash_report(
                     ex, fileitem.filepath, self.crash_file_path
@@ -1144,7 +1143,7 @@ class PyLinter(
             if verbose:
                 checked_files_count = self.stats.node_count["module"]
                 unchecked_files_count = self.stats.undocumented["module"]
-                checked_files = ', '.join(self._files_checked)
+                checked_files = ', '.join(self.stats.modules_names)
                 msg += f"\nChecked {checked_files_count} files ({checked_files}), skipped {unchecked_files_count} files"
 
         if self.config.score:

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -1143,7 +1143,7 @@ class PyLinter(
             if verbose:
                 checked_files_count = self.stats.node_count["module"]
                 unchecked_files_count = self.stats.undocumented["module"]
-                checked_files = ', '.join(self.stats.modules_names)
+                checked_files = ", ".join(self.stats.modules_names)
                 msg += f"\nChecked {checked_files_count} files ({checked_files}), skipped {unchecked_files_count} files"
 
         if self.config.score:

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -1144,7 +1144,7 @@ class PyLinter(
             if verbose:
                 checked_files_count = self.stats.node_count["module"]
                 unchecked_files_count = self.stats.undocumented["module"]
-                checked_files = ', '.join(self._files_checked)
+                checked_files = ", ".join(self._files_checked)
                 msg += f"\nChecked {checked_files_count} files ({checked_files}), skipped {unchecked_files_count} files"
 
         if self.config.score:

--- a/pylint/utils/linterstats.py
+++ b/pylint/utils/linterstats.py
@@ -109,6 +109,7 @@ class LinterStats:
         self.code_type_count = code_type_count or CodeTypeCount(
             code=0, comment=0, docstring=0, empty=0, total=0
         )
+        self.modules_names: set[str] = set()
 
         self.dependencies: dict[str, set[str]] = dependencies or {}
         self.duplicated_lines = duplicated_lines or DuplicatedLines(


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pylint-dev/pylint#9375](https://togithub.com/pylint-dev/pylint/pull/9375).



The original branch is fork-9375-qequ/feature-print-filepaths