### PR TITLE
Update pytest requirement from ~=7.4 to ~=8.2

### DIFF
--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -3,7 +3,7 @@
 astroid==3.1.0  # Pinned to a specific version for tests
 typing-extensions~=4.11
 py~=1.11.0
-pytest~=7.4
+pytest~=8.2
 pytest-benchmark~=4.0
 pytest-timeout~=2.3
 towncrier~=23.11


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pylint-dev/pylint#9576](https://togithub.com/pylint-dev/pylint/pull/9576).



The original branch is upstream/dependabot/pip/pytest-approx-eq-8.2