### PR TITLE
Update pytest-xdist requirement from ~=3.5 to ~=3.6

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,7 +4,7 @@ tbump~=6.11.0
 contributors-txt>=1.0.0
 pytest-cov~=5.0
 pytest-profiling~=1.7
-pytest-xdist~=3.5
+pytest-xdist~=3.6
 six
 # Type packages for mypy
 types-pkg_resources==0.1.3


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pylint-dev/pylint#9575](https://togithub.com/pylint-dev/pylint/pull/9575).



The original branch is upstream/dependabot/pip/pytest-xdist-approx-eq-3.6