### PR TITLE
Fix false negative for ``property-with-parameters``

### DIFF
--- a/doc/whatsnew/fragments/9584.false_negative
+++ b/doc/whatsnew/fragments/9584.false_negative
@@ -1,0 +1,3 @@
+Fix false negative for ``property-with-parameters`` in the case of parameters which are ``positional-only``, ``keyword-only``, ``variadic positional`` or ``variadic keyword``.
+
+Closes #9584

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1410,8 +1410,7 @@ a metaclass class method.",
 
     def _check_property_with_parameters(self, node: nodes.FunctionDef) -> None:
         if (
-            node.args.args
-            and len(node.args.args) > 1
+            len(node.args.arguments) > 1
             and decorated_with_property(node)
             and not is_property_setter(node)
         ):

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1414,7 +1414,7 @@ a metaclass class method.",
             and decorated_with_property(node)
             and not is_property_setter(node)
         ):
-            self.add_message("property-with-parameters", node=node)
+            self.add_message("property-with-parameters", node=node, confidence=HIGH)
 
     def _check_invalid_overridden_method(
         self,

--- a/tests/functional/p/property_with_parameters.py
+++ b/tests/functional/p/property_with_parameters.py
@@ -4,8 +4,24 @@ from abc import ABCMeta, abstractmethod
 
 class Cls:
     @property
-    def attribute(self, param, param1): # [property-with-parameters]
-        return param + param1
+    def a(self, arg):  # [property-with-parameters]
+        return arg
+
+    @property
+    def b(self, arg, /):  # [property-with-parameters]
+        return arg
+
+    @property
+    def c(self, *, arg):  # [property-with-parameters]
+        return arg
+
+    @property
+    def d(self, *args):  # [property-with-parameters]
+        return args
+
+    @property
+    def e(self, **kwargs):  # [property-with-parameters]
+        return kwargs
 
 
 class MyClassBase(metaclass=ABCMeta):

--- a/tests/functional/p/property_with_parameters.txt
+++ b/tests/functional/p/property_with_parameters.txt
@@ -1,5 +1,5 @@
-property-with-parameters:7:4:7:9:Cls.a:Cannot have defined parameters for properties:UNDEFINED
-property-with-parameters:11:4:11:9:Cls.b:Cannot have defined parameters for properties:UNDEFINED
-property-with-parameters:15:4:15:9:Cls.c:Cannot have defined parameters for properties:UNDEFINED
-property-with-parameters:19:4:19:9:Cls.d:Cannot have defined parameters for properties:UNDEFINED
-property-with-parameters:23:4:23:9:Cls.e:Cannot have defined parameters for properties:UNDEFINED
+property-with-parameters:7:4:7:9:Cls.a:Cannot have defined parameters for properties:HIGH
+property-with-parameters:11:4:11:9:Cls.b:Cannot have defined parameters for properties:HIGH
+property-with-parameters:15:4:15:9:Cls.c:Cannot have defined parameters for properties:HIGH
+property-with-parameters:19:4:19:9:Cls.d:Cannot have defined parameters for properties:HIGH
+property-with-parameters:23:4:23:9:Cls.e:Cannot have defined parameters for properties:HIGH

--- a/tests/functional/p/property_with_parameters.txt
+++ b/tests/functional/p/property_with_parameters.txt
@@ -1,1 +1,5 @@
-property-with-parameters:7:4:7:17:Cls.attribute:Cannot have defined parameters for properties:UNDEFINED
+property-with-parameters:7:4:7:9:Cls.a:Cannot have defined parameters for properties:UNDEFINED
+property-with-parameters:11:4:11:9:Cls.b:Cannot have defined parameters for properties:UNDEFINED
+property-with-parameters:15:4:15:9:Cls.c:Cannot have defined parameters for properties:UNDEFINED
+property-with-parameters:19:4:19:9:Cls.d:Cannot have defined parameters for properties:UNDEFINED
+property-with-parameters:23:4:23:9:Cls.e:Cannot have defined parameters for properties:UNDEFINED


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pylint-dev/pylint#9592](https://togithub.com/pylint-dev/pylint/pull/9592).



The original branch is fork-9592-mbyrnepr2/9584_false_negative