### PR TITLE
replace deprecated m*ster_doc with root_doc

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -106,8 +106,8 @@ source_suffix = ".rst"
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = "index"
+# The root toctree document.
+root_doc = "index"
 
 # General information about the project.
 project = "Pylint"


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pylint-dev/pylint#9600](https://togithub.com/pylint-dev/pylint/pull/9600).



The original branch is fork-9600-graingert/replace-deprecated-m-ster-doc-with-root-doc