### PR TITLE
[performance] Check that 'trailing-comma-tuple' is enabled only once

### DIFF
--- a/doc/data/messages/t/trailing-comma-tuple/details.rst
+++ b/doc/data/messages/t/trailing-comma-tuple/details.rst
@@ -1,0 +1,2 @@
+Known issue: It's impossible to reactivate ``trailing-comma-tuple`` using message control
+once it's been disabled for a file due to over-optimization.

--- a/doc/whatsnew/fragments/9608.performance
+++ b/doc/whatsnew/fragments/9608.performance
@@ -1,0 +1,4 @@
+An internal check for ``trailing-comma-tuple`` being globally enabled or not is now
+done once per file instead of once for each token.
+
+Refs #9608.

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -648,6 +648,10 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         self.add_message("simplifiable-if-statement", node=node, args=(reduced_to,))
 
     def process_tokens(self, tokens: list[tokenize.TokenInfo]) -> None:
+        # Optimization flag because '_is_trailing_comma' is costly
+        trailing_comma_tuple_enabled_for_file = self.linter.is_message_enabled(
+            "trailing-comma-tuple"
+        )
         # Process tokens and look for 'if' or 'elif'
         for index, token in enumerate(tokens):
             token_string = token[1]
@@ -659,9 +663,9 @@ class RefactoringChecker(checkers.BaseTokenChecker):
                 # token[2] is the actual position and also is
                 # reported by IronPython.
                 self._elifs.extend([token[2], tokens[index + 1][2]])
-            elif self.linter.is_message_enabled(
-                "trailing-comma-tuple"
-            ) and _is_trailing_comma(tokens, index):
+            elif trailing_comma_tuple_enabled_for_file and _is_trailing_comma(
+                tokens, index
+            ):
                 self.add_message("trailing-comma-tuple", line=token.start[0])
 
     @utils.only_required_for_messages("consider-using-with")


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pylint-dev/pylint#9620](https://togithub.com/pylint-dev/pylint/pull/9620).



The original branch is fork-9620-Pierre-Sassoulas/optimization-without-bug-fix