### PR TITLE
Fix a false negative for ``--ignore-patterns``

### DIFF
--- a/doc/whatsnew/fragments/9273.false_negative
+++ b/doc/whatsnew/fragments/9273.false_negative
@@ -1,0 +1,3 @@
+Fix a false negative for ``--ignore-patterns`` when the directory to be linted is specified using a dot(``.``) and all files are ignored instead of only the files whose name begin with a dot.
+
+Closes #9273

--- a/pylint/lint/expand_modules.py
+++ b/pylint/lint/expand_modules.py
@@ -8,6 +8,7 @@ import os
 import sys
 from collections.abc import Sequence
 from re import Pattern
+from pathlib import Path
 
 from astroid import modutils
 
@@ -58,7 +59,7 @@ def _is_ignored_file(
     ignore_list_paths_re: list[Pattern[str]],
 ) -> bool:
     element = os.path.normpath(element)
-    basename = os.path.basename(element)
+    basename = Path(element).absolute().name
     return (
         basename in ignore_list
         or _is_in_ignore_list_re(basename, ignore_list_re)

--- a/pylint/lint/expand_modules.py
+++ b/pylint/lint/expand_modules.py
@@ -7,8 +7,8 @@ from __future__ import annotations
 import os
 import sys
 from collections.abc import Sequence
-from re import Pattern
 from pathlib import Path
+from re import Pattern
 
 from astroid import modutils
 

--- a/tests/regrtest_data/ignore_pattern/.hidden/module.py
+++ b/tests/regrtest_data/ignore_pattern/.hidden/module.py
@@ -1,0 +1,1 @@
+import os

--- a/tests/regrtest_data/ignore_pattern/module.py
+++ b/tests/regrtest_data/ignore_pattern/module.py
@@ -1,0 +1,1 @@
+import os

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -1203,7 +1203,7 @@ a.py:1:4: E0001: Parsing failed: 'invalid syntax (a, line 1)' (syntax-error)"""
         )
 
     @pytest.mark.parametrize("ignore_pattern_value", ["^\\.", "^\\..+", "^\\..*"])
-    def test_ignore_pattern_recursive_rel_path(self, ignore_pattern_value) -> None:
+    def test_ignore_pattern_recursive_rel_path(self, ignore_pattern_value: str) -> None:
         """Test that ``--ignore-patterns`` strictly only ignores files
         whose names begin with a "." when a dot is used to specify the
         current directory.

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -1202,6 +1202,27 @@ a.py:1:4: E0001: Parsing failed: 'invalid syntax (a, line 1)' (syntax-error)"""
             code=0,
         )
 
+    @pytest.mark.parametrize("ignore_pattern_value", ["^\\.", "^\\..+", "^\\..*"])
+    def test_ignore_pattern_recursive_rel_path(self, ignore_pattern_value) -> None:
+        """Test that ``--ignore-patterns`` strictly only ignores files
+        whose names begin with a "." when a dot is used to specify the
+        current directory.
+        """
+        expected = "module.py:1:0: W0611: Unused import os (unused-import)"
+        unexpected = ".hidden/module.py:1:0: W0611: Unused import os (unused-import)"
+
+        with _test_cwd():
+            os.chdir(join(HERE, "regrtest_data", "ignore_pattern"))
+            self._test_output(
+                [
+                    ".",
+                    "--recursive=y",
+                    f"--ignore-patterns={ignore_pattern_value}",
+                ],
+                expected_output=expected,
+                unexpected_output=unexpected,
+            )
+
     def test_ignore_pattern_from_stdin(self) -> None:
         """Test if linter ignores standard input if the filename matches the ignore pattern."""
         with mock.patch("pylint.lint.pylinter._read_stdin", return_value="import os\n"):


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pylint-dev/pylint#9630](https://togithub.com/pylint-dev/pylint/pull/9630).



The original branch is fork-9630-mbyrnepr2/9273_ignore_patterns_ignores_too_much