### PR TITLE
Don't emit incorrect-variance for type parameters (PEP 695)

### DIFF
--- a/doc/whatsnew/fragments/9638.false_positive
+++ b/doc/whatsnew/fragments/9638.false_positive
@@ -1,0 +1,5 @@
+Don't emit ``typevar-name-incorrect-variance`` warnings for PEP 695 style TypeVars.
+The variance is inferred automatically by the type checker.
+Adding ``_co`` or ``_contra`` suffix can help to reason about TypeVar.
+
+Refs #9638

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -60,6 +60,7 @@ class TypeVarVariance(Enum):
     covariant = auto()
     contravariant = auto()
     double_variant = auto()
+    inferred = auto()
 
 
 def _get_properties(config: argparse.Namespace) -> tuple[set[str], set[str]]:
@@ -623,6 +624,7 @@ class NameChecker(_BasicChecker):
 
     def _check_typevar(self, name: str, node: nodes.AssignName) -> None:
         """Check for TypeVar lint violations."""
+        variance: TypeVarVariance = TypeVarVariance.invariant
         if isinstance(node.parent, nodes.Assign):
             keywords = node.assign_type().value.keywords
             args = node.assign_type().value.args
@@ -634,8 +636,8 @@ class NameChecker(_BasicChecker):
         else:  # PEP 695 generic type nodes
             keywords = ()
             args = ()
+            variance = TypeVarVariance.inferred
 
-        variance = TypeVarVariance.invariant
         name_arg = None
         for kw in keywords:
             if variance == TypeVarVariance.double_variant:
@@ -659,7 +661,12 @@ class NameChecker(_BasicChecker):
         if name_arg is None and args and isinstance(args[0], nodes.Const):
             name_arg = args[0].value
 
-        if variance == TypeVarVariance.double_variant:
+        if variance == TypeVarVariance.inferred:
+            # Ignore variance check for PEP 695 type parameters.
+            # The variance is inferred by the type checker.
+            # Adding _co or _contra suffix can help to reason about TypeVar.
+            pass
+        elif variance == TypeVarVariance.double_variant:
             self.add_message(
                 "typevar-double-variance",
                 node=node,

--- a/tests/functional/t/type/typevar_naming_style_py312.py
+++ b/tests/functional/t/type/typevar_naming_style_py312.py
@@ -1,4 +1,10 @@
 """PEP 695 generic typing nodes"""
 
+from collections.abc import Sequence
+
 type Point[T] = tuple[T, ...]
 type Point[t] = tuple[t, ...]  # [invalid-name]
+
+# Don't report typevar-name-incorrect-variance for type parameter
+# The variance is determined by the type checker
+type Array[T_co] = Sequence[T_co]

--- a/tests/functional/t/type/typevar_naming_style_py312.txt
+++ b/tests/functional/t/type/typevar_naming_style_py312.txt
@@ -1,1 +1,1 @@
-invalid-name:4:11:4:12::"Type variable name ""t"" doesn't conform to predefined naming style":HIGH
+invalid-name:6:11:6:12::"Type variable name ""t"" doesn't conform to predefined naming style":HIGH


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pylint-dev/pylint#9638](https://togithub.com/pylint-dev/pylint/pull/9638).



The original branch is fork-9638-cdce8p/pep695-variance