### PR TITLE
Fix a false negative for ``duplicate-argument-name``

### DIFF
--- a/doc/user_guide/checkers/features.rst
+++ b/doc/user_guide/checkers/features.rst
@@ -65,7 +65,7 @@ Basic checker Messages
   methods and is instantiated.
 :star-needs-assignment-target (E0114): *Can use starred expression only in assignment target*
   Emitted when a star expression is not used in an assignment target.
-:duplicate-argument-name (E0108): *Duplicate argument name %s in function definition*
+:duplicate-argument-name (E0108): *Duplicate argument name %r in function definition*
   Duplicate argument names in function definitions are syntax errors.
 :return-in-init (E0101): *Explicit return in __init__*
   Used when the special class method __init__ has an explicit return value.

--- a/doc/whatsnew/fragments/9669.false_negative
+++ b/doc/whatsnew/fragments/9669.false_negative
@@ -1,3 +1,3 @@
-Fix a false negative for ``duplicate-argument-name`` by including ``positional-only``, ``*args`` and ``**kwargs`` arguments in the check. 
+Fix a false negative for ``duplicate-argument-name`` by including ``positional-only``, ``*args`` and ``**kwargs`` arguments in the check.
 
 Closes #9669

--- a/doc/whatsnew/fragments/9669.false_negative
+++ b/doc/whatsnew/fragments/9669.false_negative
@@ -1,0 +1,3 @@
+Fix a false negative for ``duplicate-argument-name`` by including ``positional-only``, ``*args`` and ``**kwargs`` arguments in the check. 
+
+Closes #9669

--- a/pylint/checkers/base/basic_error_checker.py
+++ b/pylint/checkers/base/basic_error_checker.py
@@ -285,8 +285,7 @@ class BasicErrorChecker(_BasicChecker):
                     self.add_message("return-in-init", node=node)
         # Check for duplicate names by clustering args with same name for detailed report
         arg_clusters = {}
-        arguments: Iterator[Any] = node.args.arguments
-        for arg in arguments:
+        for arg in node.args.arguments:
             if arg.name in arg_clusters:
                 self.add_message(
                     "duplicate-argument-name",

--- a/pylint/checkers/base/basic_error_checker.py
+++ b/pylint/checkers/base/basic_error_checker.py
@@ -7,8 +7,6 @@
 from __future__ import annotations
 
 import itertools
-from collections.abc import Iterator
-from typing import Any
 
 import astroid
 from astroid import nodes

--- a/pylint/checkers/base/basic_error_checker.py
+++ b/pylint/checkers/base/basic_error_checker.py
@@ -145,7 +145,7 @@ class BasicErrorChecker(_BasicChecker):
             "pre-decrement operator -- and ++, which doesn't exist in Python.",
         ),
         "E0108": (
-            "Duplicate argument name %s in function definition",
+            "Duplicate argument name %r in function definition",
             "duplicate-argument-name",
             "Duplicate argument names in function definitions are syntax errors.",
         ),
@@ -285,8 +285,8 @@ class BasicErrorChecker(_BasicChecker):
                     self.add_message("return-in-init", node=node)
         # Check for duplicate names by clustering args with same name for detailed report
         arg_clusters = {}
-        arguments: Iterator[Any] = filter(None, [node.args.args, node.args.kwonlyargs])
-        for arg in itertools.chain.from_iterable(arguments):
+        arguments: Iterator[Any] = node.args.arguments
+        for arg in arguments:
             if arg.name in arg_clusters:
                 self.add_message(
                     "duplicate-argument-name",

--- a/tests/functional/a/async_functions.txt
+++ b/tests/functional/a/async_functions.txt
@@ -5,6 +5,6 @@ too-many-arguments:26:0:26:26:complex_function:Too many arguments (10/5):UNDEFIN
 too-many-branches:26:0:26:26:complex_function:Too many branches (13/12):UNDEFINED
 too-many-return-statements:26:0:26:26:complex_function:Too many return statements (10/6):UNDEFINED
 dangerous-default-value:59:0:59:14:func:Dangerous default value [] as argument:UNDEFINED
-duplicate-argument-name:59:18:59:19:func:Duplicate argument name a in function definition:HIGH
+duplicate-argument-name:59:18:59:19:func:Duplicate argument name 'a' in function definition:HIGH
 disallowed-name:64:0:64:13:foo:"Disallowed name ""foo""":HIGH
 empty-docstring:64:0:64:13:foo:Empty function docstring:HIGH

--- a/tests/functional/d/duplicate/duplicate_argument_name.py
+++ b/tests/functional/d/duplicate/duplicate_argument_name.py
@@ -1,14 +1,23 @@
 """Check for duplicate function arguments."""
 
+# pylint: disable=missing-docstring, line-too-long
+
 
 def foo1(_, _): # [duplicate-argument-name]
-    """Function with duplicate argument name."""
+    ...
 
 def foo2(_abc, *, _abc): # [duplicate-argument-name]
-    """Function with duplicate argument name."""
+    ...
 
 def foo3(_, _=3): # [duplicate-argument-name]
-    """Function with duplicate argument name."""
+    ...
 
 def foo4(_, *, _): # [duplicate-argument-name]
-    """Function with duplicate argument name."""
+    ...
+
+def foo5(_, *_, _=3): # [duplicate-argument-name, duplicate-argument-name]
+    ...
+
+# +1: [duplicate-argument-name, duplicate-argument-name, duplicate-argument-name, duplicate-argument-name]
+def foo6(_, /, _, *_, _="_", **_):
+    ...

--- a/tests/functional/d/duplicate/duplicate_argument_name.py
+++ b/tests/functional/d/duplicate/duplicate_argument_name.py
@@ -1,6 +1,6 @@
 """Check for duplicate function arguments."""
 
-# pylint: disable=missing-docstring, line-too-long
+# pylint: disable=missing-docstring, line-too-long, unused-argument
 
 
 def foo1(_, _): # [duplicate-argument-name]
@@ -18,6 +18,11 @@ def foo4(_, *, _): # [duplicate-argument-name]
 def foo5(_, *_, _=3): # [duplicate-argument-name, duplicate-argument-name]
     ...
 
-# +1: [duplicate-argument-name, duplicate-argument-name, duplicate-argument-name, duplicate-argument-name]
-def foo6(_, /, _, *_, _="_", **_):
+def foo6(a, *a): # [duplicate-argument-name]
+    ...
+
+def foo7(a, /, a): # [duplicate-argument-name]
+    ...
+
+def foo8(a, **a): # [duplicate-argument-name]
     ...

--- a/tests/functional/d/duplicate/duplicate_argument_name.txt
+++ b/tests/functional/d/duplicate/duplicate_argument_name.txt
@@ -4,7 +4,6 @@ duplicate-argument-name:12:12:12:13:foo3:Duplicate argument name '_' in function
 duplicate-argument-name:15:15:15:16:foo4:Duplicate argument name '_' in function definition:HIGH
 duplicate-argument-name:18:13:18:14:foo5:Duplicate argument name '_' in function definition:HIGH
 duplicate-argument-name:18:16:18:17:foo5:Duplicate argument name '_' in function definition:HIGH
-duplicate-argument-name:22:15:22:16:foo6:Duplicate argument name '_' in function definition:HIGH
-duplicate-argument-name:22:19:22:20:foo6:Duplicate argument name '_' in function definition:HIGH
-duplicate-argument-name:22:22:22:23:foo6:Duplicate argument name '_' in function definition:HIGH
-duplicate-argument-name:22:31:22:32:foo6:Duplicate argument name '_' in function definition:HIGH
+duplicate-argument-name:21:13:21:14:foo6:Duplicate argument name 'a' in function definition:HIGH
+duplicate-argument-name:24:15:24:16:foo7:Duplicate argument name 'a' in function definition:HIGH
+duplicate-argument-name:27:14:27:15:foo8:Duplicate argument name 'a' in function definition:HIGH

--- a/tests/functional/d/duplicate/duplicate_argument_name.txt
+++ b/tests/functional/d/duplicate/duplicate_argument_name.txt
@@ -1,4 +1,10 @@
-duplicate-argument-name:4:12:4:13:foo1:Duplicate argument name _ in function definition:HIGH
-duplicate-argument-name:7:18:7:22:foo2:Duplicate argument name _abc in function definition:HIGH
-duplicate-argument-name:10:12:10:13:foo3:Duplicate argument name _ in function definition:HIGH
-duplicate-argument-name:13:15:13:16:foo4:Duplicate argument name _ in function definition:HIGH
+duplicate-argument-name:6:12:6:13:foo1:Duplicate argument name '_' in function definition:HIGH
+duplicate-argument-name:9:18:9:22:foo2:Duplicate argument name '_abc' in function definition:HIGH
+duplicate-argument-name:12:12:12:13:foo3:Duplicate argument name '_' in function definition:HIGH
+duplicate-argument-name:15:15:15:16:foo4:Duplicate argument name '_' in function definition:HIGH
+duplicate-argument-name:18:13:18:14:foo5:Duplicate argument name '_' in function definition:HIGH
+duplicate-argument-name:18:16:18:17:foo5:Duplicate argument name '_' in function definition:HIGH
+duplicate-argument-name:22:15:22:16:foo6:Duplicate argument name '_' in function definition:HIGH
+duplicate-argument-name:22:19:22:20:foo6:Duplicate argument name '_' in function definition:HIGH
+duplicate-argument-name:22:22:22:23:foo6:Duplicate argument name '_' in function definition:HIGH
+duplicate-argument-name:22:31:22:32:foo6:Duplicate argument name '_' in function definition:HIGH

--- a/tests/functional/d/duplicate/duplicate_argument_name_py3.py
+++ b/tests/functional/d/duplicate/duplicate_argument_name_py3.py
@@ -1,5 +1,0 @@
-"""Check for duplicate function keywordonly arguments."""
-
-
-def foo1(_, *_, _=3): # [duplicate-argument-name]
-    """Function with duplicate argument name."""

--- a/tests/functional/d/duplicate/duplicate_argument_name_py3.txt
+++ b/tests/functional/d/duplicate/duplicate_argument_name_py3.txt
@@ -1,1 +1,0 @@
-duplicate-argument-name:4:16:4:17:foo1:Duplicate argument name _ in function definition:HIGH


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pylint-dev/pylint#9670](https://togithub.com/pylint-dev/pylint/pull/9670).



The original branch is fork-9670-mbyrnepr2/9669_false_negative_duplicate_argument_name