### PR TITLE
Update typing-extensions requirement from ~=4.11 to ~=4.12

### DIFF
--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -1,7 +1,7 @@
 .[testutils,spelling]
 # astroid dependency is also defined in pyproject.toml
 astroid==3.2.2  # Pinned to a specific version for tests
-typing-extensions~=4.11
+typing-extensions~=4.12
 py~=1.11.0
 pytest~=7.4
 pytest-benchmark~=4.0


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pylint-dev/pylint#9676](https://togithub.com/pylint-dev/pylint/pull/9676).



The original branch is upstream/dependabot/pip/typing-extensions-approx-eq-4.12