### PR TITLE
Declare function mutators with inline comment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,3 @@ build-stamp
 .pytest_cache/
 .mypy_cache/
 .benchmarks/
-venv

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ build-stamp
 .pytest_cache/
 .mypy_cache/
 .benchmarks/
+venv

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -382,9 +382,10 @@ MSGS: dict[str, MessageDefinitionTuple] = {
         "a custom __getitem__ method.",
     ),
     "E1145": (
-        "",
-        "decorator-preserves-signature",
-        "Ignore invalid argument errors on calls to this function",
+        "Decorator does not preserve function signature",
+        "signature-mutator",
+        "Emitted when a decorator does not preserve the signature "
+        "of the functions is takes as inputs.",
     ),
     "W1113": (
         "Keyword argument before variable positional arguments list "

--- a/tests/functional/a/arguments.py
+++ b/tests/functional/a/arguments.py
@@ -240,6 +240,17 @@ def other_mutation_decorator(fun):
     return wrapper
 
 
+def yet_another_mutation_decorator(fun):  # pylint: disable=decorator-preserves-signature
+    """Yet another decorator that changes a function's signature"""
+    def wrapper(*args, do_something=True, **kwargs):
+        if do_something:
+            return fun(*args, **kwargs)
+
+        return None
+
+    return wrapper
+
+
 @mutation_decorator
 def mutated_function(arg):
     return arg
@@ -250,11 +261,17 @@ def mutated(arg):
     return arg
 
 
+@yet_another_mutation_decorator
+def another_mutated_function(arg):
+    return arg
+
+
 mutated_function(do_something=False)
 mutated_function()
 
 mutated(do_something=True)
 
+another_mutated_function(do_something=False)
 
 def func(one, two, three):
     return one + two + three

--- a/tests/functional/a/arguments.py
+++ b/tests/functional/a/arguments.py
@@ -240,7 +240,7 @@ def other_mutation_decorator(fun):
     return wrapper
 
 
-def yet_another_mutation_decorator(fun):  # pylint: disable=decorator-preserves-signature
+def yet_another_mutation_decorator(fun):  # pylint: disable=signature-mutator
     """Yet another decorator that changes a function's signature"""
     def wrapper(*args, do_something=True, **kwargs):
         if do_something:


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pylint-dev/pylint#8332](https://togithub.com/pylint-dev/pylint/pull/8332).



The original branch is fork-8332-rmorshea/decorator-preserves-signature-option