### PR TITLE
Fix false positive in `use-yield-from` when using `yield` return

### DIFF
--- a/doc/whatsnew/fragments/9696.false_positive
+++ b/doc/whatsnew/fragments/9696.false_positive
@@ -1,0 +1,3 @@
+Fix a false positive for ``use-yield-from`` when using the return value from the ``yield`` atom.
+
+Closes #9696

--- a/tests/functional/u/use/use_yield_from.py
+++ b/tests/functional/u/use/use_yield_from.py
@@ -57,3 +57,13 @@ async def async_for_yield(agen):
 async def async_yield(agen):
     for item in agen:
         yield item
+
+
+# If the return from `yield` is used inline, don't suggest delegation.
+
+def yield_use_send():
+    for item in (1, 2, 3):
+        _ = yield item
+    total = 0
+    for item in (1, 2, 3):
+        total += yield item


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pylint-dev/pylint#9700](https://togithub.com/pylint-dev/pylint/pull/9700).



The original branch is fork-9700-jakelishman/yield-from