### PR TITLE
[unnecessary-list-index-lookup] Fix crashes for uninferrable 'start' value in 'enumerate'

### DIFF
--- a/doc/whatsnew/fragments/9078.bugfix
+++ b/doc/whatsnew/fragments/9078.bugfix
@@ -1,0 +1,4 @@
+Fixed a crash when the ``start`` value in an ``enumerate`` was non-constant and impossible to infer
+(like in``enumerate(apples, start=int(random_apple_index)``) for ``unnecessary-list-index-lookup``.
+
+Closes #9078

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -2455,7 +2455,7 @@ class RefactoringChecker(checkers.BaseTokenChecker):
         ):
             inferred = utils.safe_infer(node)
             start_val = None
-            if inferred and isinstance(inferred, nodes.Const):
+            if isinstance(inferred, nodes.Const):
                 # inferred can be an astroid.base.Instance not only a nodes.Const,
                 # as in 'enumerate(x, int(y))'
                 start_val = inferred.value

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -2454,7 +2454,11 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             and isinstance(node.operand, (nodes.Attribute, nodes.Name))
         ):
             inferred = utils.safe_infer(node)
-            start_val = inferred.value if inferred else None
+            start_val = None
+            if inferred and isinstance(inferred, nodes.Const):
+                # inferred can be an astroid.base.Instance not only a nodes.Const,
+                # as in 'enumerate(x, int(y))'
+                start_val = inferred.value
             return start_val, INFERENCE
         if isinstance(node, nodes.UnaryOp):
             return node.operand.value, HIGH

--- a/pylint/checkers/refactoring/refactoring_checker.py
+++ b/pylint/checkers/refactoring/refactoring_checker.py
@@ -2454,11 +2454,9 @@ class RefactoringChecker(checkers.BaseTokenChecker):
             and isinstance(node.operand, (nodes.Attribute, nodes.Name))
         ):
             inferred = utils.safe_infer(node)
-            start_val = None
-            if isinstance(inferred, nodes.Const):
-                # inferred can be an astroid.base.Instance not only a nodes.Const,
-                # as in 'enumerate(x, int(y))'
-                start_val = inferred.value
+            # inferred can be an astroid.base.Instance as in 'enumerate(x, int(y))' or
+            # not correctly inferred (None)
+            start_val = inferred.value if isinstance(inferred, nodes.Const) else None
             return start_val, INFERENCE
         if isinstance(node, nodes.UnaryOp):
             return node.operand.value, HIGH

--- a/tests/functional/u/unnecessary/unnecessary_list_index_lookup.py
+++ b/tests/functional/u/unnecessary/unnecessary_list_index_lookup.py
@@ -156,3 +156,14 @@ for y, x in enumerate(nums, start=Y_START + 1):
 for idx, val in enumerate(my_list):
     if (val := 42) and my_list[idx] == 'b':
         print(1)
+
+def regression_9078(apples, cant_infer_this):
+    """Regression test for https://github.com/pylint-dev/pylint/issues/9078."""
+    for _, _ in enumerate(apples, int(cant_infer_this)):
+        ...
+
+def random_uninferrable_start(pears):
+    import random # pylint: disable=import-outside-toplevel
+
+    for _, _ in enumerate(pears, random.choice([5, 42])):
+        ...


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pylint-dev/pylint#9704](https://togithub.com/pylint-dev/pylint/pull/9704).



The original branch is upstream/unnecessary-list-index-lookup-crash