### PR TITLE
[undefined-variable] Fix a crash for undefined lineno in annotations

### DIFF
--- a/doc/whatsnew/fragments/8866.bugfix
+++ b/doc/whatsnew/fragments/8866.bugfix
@@ -1,0 +1,3 @@
+Fixed a crash when the lineno of a variable used as an annotation wasn't available for ``undefined-variable``.
+
+Closes #8866

--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -2295,13 +2295,14 @@ class VariablesChecker(BaseChecker):
             # using a name defined earlier in the class containing the function.
             if node is frame.returns and defframe.parent_of(frame.returns):
                 annotation_return = True
-                if (
-                    frame.returns.name in defframe.locals
-                    and defframe.locals[node.name][0].lineno < frame.lineno
-                ):
-                    # Detect class assignments with a name defined earlier in the
-                    # class. In this case, no warning should be raised.
-                    maybe_before_assign = False
+                if frame.returns.name in defframe.locals:
+                    definition = defframe.locals[node.name][0]
+                    if definition.lineno is None or definition.lineno < frame.lineno:
+                        # Detect class assignments with a name defined earlier in the
+                        # class. In this case, no warning should be raised.
+                        maybe_before_assign = False
+                    else:
+                        maybe_before_assign = True
                 else:
                     maybe_before_assign = True
             if isinstance(node.parent, nodes.Arguments):

--- a/tests/functional/u/undefined/undefined_variable.py
+++ b/tests/functional/u/undefined/undefined_variable.py
@@ -380,3 +380,7 @@ class RepeatedReturnAnnotations:
         pass
     def z(self) -> RepeatedReturnAnnotations:  # [undefined-variable]
         pass
+
+class A:
+    def say_hello(self) -> __module__:  # [undefined-variable]
+        ...

--- a/tests/functional/u/undefined/undefined_variable.txt
+++ b/tests/functional/u/undefined/undefined_variable.txt
@@ -37,3 +37,4 @@ undefined-variable:365:10:365:20:global_var_mixed_assignment:Undefined variable 
 undefined-variable:377:19:377:44:RepeatedReturnAnnotations.x:Undefined variable 'RepeatedReturnAnnotations':UNDEFINED
 undefined-variable:379:19:379:44:RepeatedReturnAnnotations.y:Undefined variable 'RepeatedReturnAnnotations':UNDEFINED
 undefined-variable:381:19:381:44:RepeatedReturnAnnotations.z:Undefined variable 'RepeatedReturnAnnotations':UNDEFINED
+undefined-variable:385:27:385:37:A.say_hello:Undefined variable '__module__':UNDEFINED


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pylint-dev/pylint#9705](https://togithub.com/pylint-dev/pylint/pull/9705).



The original branch is upstream/undefined-variable-crash