### PR TITLE
Gracefully handle invalid paths csv regex in conf/args

### DIFF
--- a/doc/whatsnew/fragments/9680.bugfix
+++ b/doc/whatsnew/fragments/9680.bugfix
@@ -1,0 +1,4 @@
+Impossible to compile regexes for paths in the configuration or argument given to pylint won't crash anymore but
+raise an argparse error and display the error message from ``re.compile`` instead.
+
+Closes #9680

--- a/pylint/config/argument.py
+++ b/pylint/config/argument.py
@@ -103,7 +103,7 @@ def _py_version_transformer(value: str) -> tuple[int, ...]:
 
 
 def _regex_transformer(value: str) -> Pattern[str]:
-    """Return `re.compile(value)`."""
+    """Prevents 're.error' from propagating and crash pylint."""
     try:
         return re.compile(value)
     except re.error as e:
@@ -124,7 +124,7 @@ def _regexp_paths_csv_transfomer(value: str) -> Sequence[Pattern[str]]:
     patterns: list[Pattern[str]] = []
     for pattern in _csv_transformer(value):
         patterns.append(
-            re.compile(
+            _regex_transformer(
                 str(pathlib.PureWindowsPath(pattern)).replace("\\", "\\\\")
                 + "|"
                 + pathlib.PureWindowsPath(pattern).as_posix()

--- a/tests/config/functional/toml/issue_9680/bad_regex_in_ignore_paths.32.out
+++ b/tests/config/functional/toml/issue_9680/bad_regex_in_ignore_paths.32.out
@@ -1,0 +1,2 @@
+usage: pylint [options]
+pylint: error: argument --ignore-paths: Error in provided regular expression: project\\tooling_context\\**|project/tooling_context/** beginning at index 27: multiple repeat

--- a/tests/config/functional/toml/issue_9680/bad_regex_in_ignore_paths.toml
+++ b/tests/config/functional/toml/issue_9680/bad_regex_in_ignore_paths.toml
@@ -1,0 +1,3 @@
+# Check that we report regex error in configuration file properly
+[tool.pylint."main"]
+ignore-paths = ['project/tooling_context/**']

--- a/tests/config/test_functional_config_loading.py
+++ b/tests/config/test_functional_config_loading.py
@@ -82,12 +82,24 @@ def test_functional_config_loading(
     expected_loaded_configuration = get_expected_configuration(
         configuration_path, default_configuration
     )
+    runner = None  # The runner can fail to init if conf is bad enough.
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore", message="The use of 'MASTER'.*", category=UserWarning
         )
-        runner = run_using_a_configuration_file(configuration_path, file_to_lint_path)
-    assert runner.linter.msg_status == expected_code
+        try:
+            runner = run_using_a_configuration_file(
+                configuration_path, file_to_lint_path
+            )
+            assert runner.linter.msg_status == expected_code
+        except SystemExit as e:
+            # Case where the conf exit with an argparse error
+            assert e.code == expected_code
+            out, err = capsys.readouterr()
+            assert out == ""
+            assert err.rstrip() == expected_output.rstrip()
+            return
+
     out, err = capsys.readouterr()
     # 'rstrip()' applied, so we can have a final newline in the expected test file
     assert expected_output.rstrip() == out.rstrip(), msg


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pylint-dev/pylint#9712](https://togithub.com/pylint-dev/pylint/pull/9712).



The original branch is fork-9712-Pierre-Sassoulas/proper-output-for-bad-regex