### PR TITLE
[release] Prevent the release pipeline from using twine 5.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           # Remove dist, build, and pylint.egg-info
           # when building locally for testing!
-          python -m pip install twine build
+          python -m pip install twine!=5.1.0 build
       - name: Build distributions
         run: |
           python -m build

--- a/doc/whatsnew/fragments/9749.bugfix
+++ b/doc/whatsnew/fragments/9749.bugfix
@@ -1,0 +1,3 @@
+Fixed a release issue when using twine 5.1.0 (See https://github.com/pypa/twine/issues/1125).
+
+Refs #9749


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pylint-dev/pylint#9749](https://togithub.com/pylint-dev/pylint/pull/9749).



The original branch is upstream/fix-release