### PR TITLE
False positive ``unreachable-code`` when using ``typing.Any`` as return in python 3.8

### DIFF
--- a/doc/whatsnew/fragments/9751.bugfix
+++ b/doc/whatsnew/fragments/9751.bugfix
@@ -1,0 +1,4 @@
+Fixed a false positive ``unreachable-code`` when using ``typing.Any`` as return type in python
+3.8, the ``typing.NoReturn`` are not taken into account anymore for python 3.8 however.
+
+Closes #9751

--- a/pylint/checkers/utils.py
+++ b/pylint/checkers/utils.py
@@ -2184,7 +2184,9 @@ def is_terminating_func(node: nodes.Call) -> bool:
                     *TYPING_NEVER,
                     *TYPING_NORETURN,
                     # In Python 3.7 - 3.8, NoReturn is alias of '_SpecialForm'
-                    "typing._SpecialForm",
+                    # "typing._SpecialForm",
+                    # But 'typing.Any' also inherits _SpecialForm
+                    # See #9751
                 )
             ):
                 return True

--- a/tests/functional/r/regression_02/regression_9751.py
+++ b/tests/functional/r/regression_02/regression_9751.py
@@ -1,0 +1,15 @@
+"""
+pylint 3.2.4 regression
+https://github.com/pylint-dev/pylint/issues/9751
+"""
+
+# pylint: disable=missing-function-docstring
+
+from typing import Any
+
+def repro() -> Any:
+    return 5
+
+def main():
+    x = repro() + 5
+    print(x)

--- a/tests/functional/u/used/used_before_assignment.py
+++ b/tests/functional/u/used/used_before_assignment.py
@@ -2,7 +2,7 @@
 # pylint: disable=consider-using-f-string, missing-function-docstring
 import datetime
 import sys
-from typing import NoReturn
+# from typing import NoReturn   # uncomment when we reunite with used_before_assignment_py38.py
 
 MSG = "hello %s" % MSG  # [used-before-assignment]
 
@@ -206,19 +206,3 @@ def inner_if_continues_outer_if_has_no_other_statements():
         else:
             order = None
         print(order)
-
-
-class PlatformChecks:
-    """https://github.com/pylint-dev/pylint/issues/9674"""
-    def skip(self, msg) -> NoReturn:
-        raise Exception(msg)  # pylint: disable=broad-exception-raised
-
-    def print_platform_specific_command(self):
-        if sys.platform == "linux":
-            cmd = "ls"
-        elif sys.platform == "win32":
-            cmd = "dir"
-        else:
-            self.skip("only runs on Linux/Windows")
-
-        print(cmd)

--- a/tests/functional/u/used/used_before_assignment_py38.py
+++ b/tests/functional/u/used/used_before_assignment_py38.py
@@ -1,0 +1,26 @@
+"""
+Temporary file until we drop python 3.8
+See https://github.com/pylint-dev/pylint/issues/9751
+Please reunite with used_before_assignment.py at this point
+"""
+
+# pylint: disable=missing-docstring
+
+import sys
+from typing import NoReturn
+
+
+class PlatformChecks:
+    """https://github.com/pylint-dev/pylint/issues/9674"""
+    def skip(self, msg) -> NoReturn:
+        raise Exception(msg)  # pylint: disable=broad-exception-raised
+
+    def print_platform_specific_command(self):
+        if sys.platform == "linux":
+            cmd = "ls"
+        elif sys.platform == "win32":
+            cmd = "dir"
+        else:
+            self.skip("only runs on Linux/Windows")
+
+        print(cmd)

--- a/tests/functional/u/used/used_before_assignment_py38.rc
+++ b/tests/functional/u/used/used_before_assignment_py38.rc
@@ -1,0 +1,2 @@
+[testoptions]
+min_pyver=3.9


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pylint-dev/pylint#9753](https://togithub.com/pylint-dev/pylint/pull/9753).



The original branch is upstream/fix-regression-9751