### PR TITLE
Improve file discovery for directories that are not packages

### DIFF
--- a/doc/user_guide/usage/run.rst
+++ b/doc/user_guide/usage/run.rst
@@ -18,8 +18,7 @@ On versions below 2.15, specifying a directory that is not an explicit package
     mydir/__init__.py:1:0: F0010: error while code parsing: Unable to load file mydir/__init__.py:
     [Errno 2] No such file or directory: 'mydir/__init__.py' (parse-error)
 
-Thus, on versions before 2.15, or when dealing with certain edge cases that have not yet been solved,
-using the ``--recursive=y`` option allows for linting a namespace package::
+Thus, on versions before 2.15 using the ``--recursive=y`` option allows for linting a namespace package::
 
     pylint --recursive=y mydir mymodule mypackage
 

--- a/doc/whatsnew/fragments/9764.bugfix
+++ b/doc/whatsnew/fragments/9764.bugfix
@@ -1,0 +1,3 @@
+Improve file discovery for directories that are not python packages.
+
+Closes #9764

--- a/pylint/lint/expand_modules.py
+++ b/pylint/lint/expand_modules.py
@@ -122,7 +122,7 @@ def expand_modules(
             )
         except ImportError:
             # Might not be acceptable, don't crash.
-            is_namespace = False
+            is_namespace = not os.path.exists(filepath)
             is_directory = os.path.isdir(something)
         else:
             is_namespace = modutils.is_namespace(spec)

--- a/tests/lint/unittest_expand_modules.py
+++ b/tests/lint/unittest_expand_modules.py
@@ -114,6 +114,25 @@ init_of_package = {
     "path": INIT_PATH,
 }
 
+# A directory that is not a python package.
+REPORTERS_PATH = Path(__file__).parent.parent / "reporters"
+test_reporters = {  # pylint: disable=consider-using-namedtuple-or-dataclass
+    str(REPORTERS_PATH / "unittest_json_reporter.py"): {
+        "path": str(REPORTERS_PATH / "unittest_json_reporter.py"),
+        "name": "reporters.unittest_json_reporter",
+        "isarg": False,
+        "basepath": str(REPORTERS_PATH / "__init__.py"),
+        "basename": "reporters",
+    },
+    str(REPORTERS_PATH / "unittest_reporting.py"): {
+        "path": str(REPORTERS_PATH / "unittest_reporting.py"),
+        "name": "reporters.unittest_reporting",
+        "isarg": False,
+        "basepath": str(REPORTERS_PATH / "__init__.py"),
+        "basename": "reporters",
+    },
+}
+
 
 def _list_expected_package_modules(
     deduplicating: bool = False,
@@ -174,6 +193,7 @@ class TestExpandModules(CheckerTestCase):
                     for module in _list_expected_package_modules()
                 },
             ),
+            ([str(Path(__file__).parent.parent / "reporters")], test_reporters),
         ],
     )
     @set_config(ignore_paths="")


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pylint-dev/pylint#9768](https://togithub.com/pylint-dev/pylint/pull/9768).



The original branch is upstream/continue-searching-for-files