### PR TITLE
Fix FN for `invalid-name` for type-annotated module constants

### DIFF
--- a/doc/whatsnew/fragments/9770.false_negative
+++ b/doc/whatsnew/fragments/9770.false_negative
@@ -1,0 +1,4 @@
+Check module-level constants with type annotations for ``invalid-name``.
+Remember to adjust ``const-naming-style`` or ``const-rgx`` to your liking.
+
+Closes #9770

--- a/pylint/checkers/base/name_checker/checker.py
+++ b/pylint/checkers/base/name_checker/checker.py
@@ -473,10 +473,10 @@ class NameChecker(_BasicChecker):
 
             # Check names defined in AnnAssign nodes
             elif isinstance(assign_type, nodes.AnnAssign):
-                if utils.is_assign_name_annotated_with(node, "Final"):
-                    self._check_name("const", node.name, node)
-                elif self._assigns_typealias(assign_type.annotation):
+                if self._assigns_typealias(assign_type.annotation):
                     self._check_name("typealias", node.name, node)
+                else:
+                    self._check_name("const", node.name, node)
 
         # Check names defined in function scopes
         elif isinstance(frame, nodes.FunctionDef):

--- a/tests/functional/ext/private_import/private_import.py
+++ b/tests/functional/ext/private_import/private_import.py
@@ -79,8 +79,8 @@ def c2_func() -> _TypeContainerC.C:
 # This is allowed since all the imports are used for typing
 from _TypeContainerExtra import TypeExtraA, TypeExtraB
 from MakerContainerExtra import GetA, GetB
-extraA: TypeExtraA = GetA()
-extraB: TypeExtraB = GetB()
+extra_a: TypeExtraA = GetA()
+extra_b: TypeExtraB = GetB()
 
 # This is not allowed because there is an import not used for typing
 from _TypeContainerExtra2 import TypeExtra2, NotTypeExtra # [import-private-name]

--- a/tests/functional/ext/private_import/private_import.rc
+++ b/tests/functional/ext/private_import/private_import.rc
@@ -1,2 +1,3 @@
 [MAIN]
 load-plugins=pylint.extensions.private_import,
+const-naming-style=snake_case

--- a/tests/functional/f/function_redefined.py
+++ b/tests/functional/f/function_redefined.py
@@ -122,7 +122,7 @@ def func(callback1=None, callback2=None):
             return 24
     return callback1(), callback2()
 
-do_something: Callable[[], int]
+do_something: Callable[[], int]  # pylint: disable=invalid-name
 
 def do_something() -> int:
     return 1

--- a/tests/functional/g/generic_alias/generic_alias_collections.py
+++ b/tests/functional/g/generic_alias/generic_alias_collections.py
@@ -110,7 +110,7 @@ class CustomImplementation(CustomAbstractCls2):  # [abstract-method,abstract-met
 # Type annotations
 var_tuple: tuple[int, int]
 var_dict: dict[int, str]
-var_orderedDict: collections.OrderedDict[int, str]
+var_ordereddict: collections.OrderedDict[int, str]
 var_container: collections.abc.Container[int]
 var_sequence: collections.abc.Sequence[int]
 var_iterable: collections.abc.Iterable[int]

--- a/tests/functional/g/generic_alias/generic_alias_collections.rc
+++ b/tests/functional/g/generic_alias/generic_alias_collections.rc
@@ -1,2 +1,5 @@
 [testoptions]
 min_pyver=3.9
+
+[MAIN]
+const-naming-style=snake_case

--- a/tests/functional/g/generic_alias/generic_alias_collections_py37.rc
+++ b/tests/functional/g/generic_alias/generic_alias_collections_py37.rc
@@ -1,2 +1,5 @@
 [testoptions]
 max_pyver=3.9
+
+[MAIN]
+const-naming-style=snake_case

--- a/tests/functional/g/generic_alias/generic_alias_collections_py37_with_typing.rc
+++ b/tests/functional/g/generic_alias/generic_alias_collections_py37_with_typing.rc
@@ -1,2 +1,5 @@
 [testoptions]
 max_pyver=3.9
+
+[MAIN]
+const-naming-style=snake_case

--- a/tests/functional/g/generic_alias/generic_alias_mixed_py39.py
+++ b/tests/functional/g/generic_alias/generic_alias_mixed_py39.py
@@ -9,7 +9,7 @@ import re
 import typing
 
 # Type annotations
-var_orderedDict: collections.OrderedDict[int, str]
+var_ordered_dict: collections.OrderedDict[int, str]
 var_container: collections.abc.Container[int]
 var_sequence: collections.abc.Sequence[int]
 var_iterable: collections.abc.Iterable[int]
@@ -17,7 +17,7 @@ var_awaitable: collections.abc.Awaitable[int]
 var_pattern: re.Pattern[int]
 var_bytestring: collections.abc.ByteString
 var_hashable: collections.abc.Hashable
-var_ContextManager: contextlib.AbstractContextManager[int]
+var_context_manager: contextlib.AbstractContextManager[int]
 
 
 # No implementation required for 'builtins'

--- a/tests/functional/g/generic_alias/generic_alias_mixed_py39.rc
+++ b/tests/functional/g/generic_alias/generic_alias_mixed_py39.rc
@@ -1,2 +1,5 @@
 [testoptions]
 min_pyver=3.9
+
+[MAIN]
+const-naming-style=snake_case

--- a/tests/functional/i/invalid/invalid_name.py
+++ b/tests/functional/i/invalid/invalid_name.py
@@ -15,6 +15,8 @@ try:
 except ValueError:
     time = None # [invalid-name]
 
+bbb: int = 42  # [invalid-name]
+
 try:
     from sys import argv, executable as python
 except ImportError:

--- a/tests/functional/i/invalid/invalid_name.txt
+++ b/tests/functional/i/invalid/invalid_name.txt
@@ -1,8 +1,9 @@
 invalid-name:12:0:12:3::"Constant name ""aaa"" doesn't conform to UPPER_CASE naming style":HIGH
 invalid-name:16:4:16:8::"Constant name ""time"" doesn't conform to UPPER_CASE naming style":HIGH
-invalid-name:36:0:36:5:A:"Function name ""A"" doesn't conform to snake_case naming style":HIGH
-invalid-name:50:4:50:13::"Constant name ""Foocapfor"" doesn't conform to UPPER_CASE naming style":HIGH
-invalid-name:66:0:66:68:a_very_very_very_long_function_name_WithCamelCase_to_make_it_sad:"Function name ""a_very_very_very_long_function_name_WithCamelCase_to_make_it_sad"" doesn't conform to snake_case naming style":HIGH
-invalid-name:74:23:74:29:FooBar.__init__:"Argument name ""fooBar"" doesn't conform to snake_case naming style":HIGH
-invalid-name:80:8:80:14:FooBar.func1:"Argument name ""fooBar"" doesn't conform to snake_case naming style":HIGH
-invalid-name:100:8:100:15:FooBar.test_disable_mixed:"Argument name ""fooBar2"" doesn't conform to snake_case naming style":HIGH
+invalid-name:18:0:18:3::"Constant name ""bbb"" doesn't conform to UPPER_CASE naming style":HIGH
+invalid-name:38:0:38:5:A:"Function name ""A"" doesn't conform to snake_case naming style":HIGH
+invalid-name:52:4:52:13::"Constant name ""Foocapfor"" doesn't conform to UPPER_CASE naming style":HIGH
+invalid-name:68:0:68:68:a_very_very_very_long_function_name_WithCamelCase_to_make_it_sad:"Function name ""a_very_very_very_long_function_name_WithCamelCase_to_make_it_sad"" doesn't conform to snake_case naming style":HIGH
+invalid-name:76:23:76:29:FooBar.__init__:"Argument name ""fooBar"" doesn't conform to snake_case naming style":HIGH
+invalid-name:82:8:82:14:FooBar.func1:"Argument name ""fooBar"" doesn't conform to snake_case naming style":HIGH
+invalid-name:102:8:102:15:FooBar.test_disable_mixed:"Argument name ""fooBar2"" doesn't conform to snake_case naming style":HIGH

--- a/tests/functional/r/regression_02/regression_3979.py
+++ b/tests/functional/r/regression_02/regression_3979.py
@@ -10,4 +10,4 @@ if TYPE_CHECKING:
 else:
     BasePathLike = os.PathLike
 
-Foo: Union[str, BasePathLike] = "bar"
+SOME_VAR: Union[str, BasePathLike] = "bar"

--- a/tests/functional/t/type/typealias_naming_style_default.py
+++ b/tests/functional/t/type/typealias_naming_style_default.py
@@ -27,8 +27,8 @@ ANOTHERBADNAME = Union[int, str]  # [invalid-name]
 
 # Regression tests
 # They are not TypeAlias, and thus shouldn't flag the message
-x: Union[str, int] = 42
-y: Union[str, int]
+X: Union[str, int] = 42
+Y: Union[str, int]
 # But the following, using a good TypeAlias name, is:
 GoodTypeAliasToUnion: TypeAlias = Union[str, int]
 

--- a/tests/functional/u/unsubscriptable_value_py37.py
+++ b/tests/functional/u/unsubscriptable_value_py37.py
@@ -14,4 +14,4 @@ class Subscriptable:
 Subscriptable[0]
 Subscriptable()[0]  # [unsubscriptable-object]
 
-a: typing.List[int]
+A: typing.List[int]

--- a/tests/functional/u/unused/unused_import_py39.py
+++ b/tests/functional/u/unused/unused_import_py39.py
@@ -7,4 +7,4 @@ from pathlib import Path  # [unused-import]
 import typing as t
 
 
-example: t.Annotated[str, "Path"] = "/foo/bar"
+EXAMPLE: t.Annotated[str, "Path"] = "/foo/bar"

--- a/tests/functional/u/unused/unused_name_in_string_literal_type_annotation.py
+++ b/tests/functional/u/unused/unused_name_in_string_literal_type_annotation.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import NoReturn, Set
 
 # unused-import shouldn't be emitted for Path
-example1: Set["Path"] = set()
+EXAMPLE1: Set["Path"] = set()
 
 def example2(_: "ArgumentParser") -> "NoReturn":
     """unused-import shouldn't be emitted for ArgumentParser or NoReturn."""
@@ -22,9 +22,9 @@ def example4(_: "PathLike[str]") -> None:
     """unused-import shouldn't be emitted for PathLike."""
 
 # pylint shouldn't crash with the following strings in a type annotation context
-example5: Set[""]
-example6: Set[" "]
-example7: Set["?"]
+EXAMPLE5: Set[""]
+EXAMPLE6: Set[" "]
+EXAMPLE7: Set["?"]
 
 class Class:
     """unused-import shouldn't be emitted for Namespace"""

--- a/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py38.py
+++ b/tests/functional/u/unused/unused_name_in_string_literal_type_annotation_py38.py
@@ -8,7 +8,7 @@ import typing as t
 from typing import Literal as Lit
 
 # str inside Literal shouldn't be treated as names
-example1: t.Literal["ArgumentParser", Lit["Namespace", "ArgumentParser"]]
+EXAMPLE1: t.Literal["ArgumentParser", Lit["Namespace", "ArgumentParser"]]
 
 
 def unused_variable_example():
@@ -19,9 +19,9 @@ def unused_variable_example():
 
 
 # pylint shouldn't crash with the following strings in a type annotation context
-example3: Lit["", " ", "?"] = "?"
+EXAMPLE3: Lit["", " ", "?"] = "?"
 
 
 # See https://peps.python.org/pep-0586/#literals-enums-and-forward-references
-example4: t.Literal["http.HTTPStatus.OK", "http.HTTPStatus.NOT_FOUND"]
-example5: "t.Literal[HTTPStatus.OK, HTTPStatus.NOT_FOUND]"
+EXAMPLE4: t.Literal["http.HTTPStatus.OK", "http.HTTPStatus.NOT_FOUND"]
+EXAMPLE5: "t.Literal[HTTPStatus.OK, HTTPStatus.NOT_FOUND]"

--- a/tests/input/func_noerror_cycle/a.py
+++ b/tests/input/func_noerror_cycle/a.py
@@ -1,8 +1,8 @@
 # pylint: disable=missing-docstring
 from typing import List
 
-from .b import var
+from .b import VAR
 
 LstT = List[int]
 
-print(var)
+print(VAR)

--- a/tests/input/func_noerror_cycle/b.py
+++ b/tests/input/func_noerror_cycle/b.py
@@ -4,4 +4,4 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .a import LstT
 
-var: "LstT" = [1, 2]
+VAR: "LstT" = [1, 2]


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pylint-dev/pylint#9771](https://togithub.com/pylint-dev/pylint/pull/9771).



The original branch is upstream/invalid-name-type-annotation