### PR TITLE
Bump actions/download-artifact from 4.1.7 to 4.1.8

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -105,7 +105,7 @@ jobs:
             ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
             needs.tests-linux.outputs.python-key }}
       - name: Download all coverage artifacts
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4.1.8
       - name: Combine coverage results
         run: |
           . venv/bin/activate


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pylint-dev/pylint#9779](https://togithub.com/pylint-dev/pylint/pull/9779).



The original branch is upstream/dependabot/github_actions/actions/download-artifact-4.1.8