### PR TITLE
Fix FP for `unexpected-keyword-arg` with ambiguous constructors

### DIFF
--- a/doc/whatsnew/fragments/9672.false_positive
+++ b/doc/whatsnew/fragments/9672.false_positive
@@ -1,0 +1,4 @@
+Quiet false positives for `unexpected-keyword-arg` when pylint cannot
+determine which of two or more ambiguous classes are being instantiated.
+
+Closes #9672

--- a/doc/whatsnew/fragments/9672.false_positive
+++ b/doc/whatsnew/fragments/9672.false_positive
@@ -1,4 +1,4 @@
 Quiet false positives for `unexpected-keyword-arg` when pylint cannot
-determine which of two or more ambiguous classes are being instantiated.
+determine which of two or more dynamically defined classes are being instantiated.
 
 Closes #9672

--- a/pylint/checkers/typecheck.py
+++ b/pylint/checkers/typecheck.py
@@ -1437,7 +1437,7 @@ accessed. Python regular expressions are accepted.",
         """Check that called functions/methods are inferred to callable objects,
         and that passed arguments match the parameters in the inferred function.
         """
-        called = safe_infer(node.func)
+        called = safe_infer(node.func, compare_constructors=True)
 
         self._check_not_callable(node, called)
 

--- a/tests/functional/u/unexpected_keyword_arg.py
+++ b/tests/functional/u/unexpected_keyword_arg.py
@@ -163,3 +163,34 @@ func4()
 # Two functions with same keyword argument but mixed defaults (names, constant)
 func5 = ambiguous_func3 if unknown else ambiguous_func5
 func5()
+
+
+# pylint: disable=unused-argument
+if do_something():
+    class AmbiguousClass:
+        def __init__(self, feeling="fine"):
+            ...
+else:
+    class AmbiguousClass:
+        def __init__(self, feeling="fine", thinking="hard"):
+            ...
+
+
+AmbiguousClass(feeling="so-so")
+AmbiguousClass(worrying="little")
+
+
+if do_something():
+    class NotAmbiguousClass:
+        def __init__(self, feeling="fine"):
+            ...
+else:
+    class NotAmbiguousClass:
+        def __init__(self, feeling="fine"):
+            ...
+
+
+NotAmbiguousClass(feeling="so-so")
+NotAmbiguousClass(worrying="little")  # [unexpected-keyword-arg]
+
+# pylint: enable=unused-argument

--- a/tests/functional/u/unexpected_keyword_arg.py
+++ b/tests/functional/u/unexpected_keyword_arg.py
@@ -177,7 +177,8 @@ else:
 
 
 AmbiguousClass(feeling="so-so")
-AmbiguousClass(worrying="little")
+AmbiguousClass(thinking="carefully")
+AmbiguousClass(worrying="little")  # we could raise here if we infer_all()
 
 
 if do_something():

--- a/tests/functional/u/unexpected_keyword_arg.txt
+++ b/tests/functional/u/unexpected_keyword_arg.txt
@@ -2,4 +2,4 @@ unexpected-keyword-arg:43:0:43:28::Unexpected keyword argument 'internal_arg' in
 unexpected-keyword-arg:73:0:73:45::Unexpected keyword argument 'internal_arg' in function call:UNDEFINED
 unexpected-keyword-arg:96:0:96:26::Unexpected keyword argument 'internal_arg' in function call:UNDEFINED
 unexpected-keyword-arg:118:0:118:30::Unexpected keyword argument 'internal_arg' in function call:UNDEFINED
-unexpected-keyword-arg:194:0:194:36::Unexpected keyword argument 'worrying' in constructor call:UNDEFINED
+unexpected-keyword-arg:195:0:195:36::Unexpected keyword argument 'worrying' in constructor call:UNDEFINED

--- a/tests/functional/u/unexpected_keyword_arg.txt
+++ b/tests/functional/u/unexpected_keyword_arg.txt
@@ -2,3 +2,4 @@ unexpected-keyword-arg:43:0:43:28::Unexpected keyword argument 'internal_arg' in
 unexpected-keyword-arg:73:0:73:45::Unexpected keyword argument 'internal_arg' in function call:UNDEFINED
 unexpected-keyword-arg:96:0:96:26::Unexpected keyword argument 'internal_arg' in function call:UNDEFINED
 unexpected-keyword-arg:118:0:118:30::Unexpected keyword argument 'internal_arg' in function call:UNDEFINED
+unexpected-keyword-arg:194:0:194:36::Unexpected keyword argument 'worrying' in constructor call:UNDEFINED


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pylint-dev/pylint#9785](https://togithub.com/pylint-dev/pylint/pull/9785).



The original branch is upstream/ambiguous-constructors