### PR TITLE
Add unsupported version checks for major 3.11 and 3.12 features

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -13,7 +13,7 @@ on:
 env:
   CACHE_VERSION: 1
   KEY_PREFIX: base-venv
-  DEFAULT_PYTHON: "3.11"
+  DEFAULT_PYTHON: "3.12"
   PRE_COMMIT_CACHE: ~/.cache/pre-commit
 
 concurrency:

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -11,7 +11,7 @@ on:
       - "maintenance/**"
 
 env:
-  CACHE_VERSION: 1
+  CACHE_VERSION: 2
   KEY_PREFIX: base-venv
   DEFAULT_PYTHON: "3.12"
   PRE_COMMIT_CACHE: ~/.cache/pre-commit

--- a/doc/data/messages/a/anomalous-backslash-in-string/bad.py
+++ b/doc/data/messages/a/anomalous-backslash-in-string/bad.py
@@ -1,1 +1,1 @@
-string = "\z"  # [anomalous-backslash-in-string]
+string = "\z"  # [syntax-error]

--- a/doc/data/messages/a/anomalous-backslash-in-string/details.rst
+++ b/doc/data/messages/a/anomalous-backslash-in-string/details.rst
@@ -1,2 +1,6 @@
 ``\z`` is same as ``\\z`` because there's no escape sequence for ``z``. But it is not clear
 for the reader of the code.
+
+The only reason this is demonstrated to raise ``syntax-error`` is because
+pylint's CI now runs on Python 3.12, where this truly raises a ``SyntaxError``.
+We hope to address this discrepancy in the documentation in the future.

--- a/doc/data/messages/a/anomalous-unicode-escape-in-string/bad.py
+++ b/doc/data/messages/a/anomalous-unicode-escape-in-string/bad.py
@@ -1,1 +1,1 @@
-print(b"\u%b" % b"0394")  # [anomalous-unicode-escape-in-string]
+print(b"\u%b" % b"0394")  # [syntax-error]

--- a/doc/data/messages/u/using-exception-groups-in-unsupported-version/bad.py
+++ b/doc/data/messages/u/using-exception-groups-in-unsupported-version/bad.py
@@ -1,0 +1,11 @@
+def f():
+    excs = [OSError("error 1"), SystemError("error 2")]
+    raise ExceptionGroup("there were problems", excs)
+
+
+try:
+    f()
+except* OSError as e:
+    print("There were OSErrors")
+except* SystemError as e:
+    print("There were SystemErrors")

--- a/doc/data/messages/u/using-exception-groups-in-unsupported-version/bad.py
+++ b/doc/data/messages/u/using-exception-groups-in-unsupported-version/bad.py
@@ -1,9 +1,10 @@
 def f():
     excs = [OSError("error 1"), SystemError("error 2")]
+    # +1: [using-exception-groups-in-unsupported-version]
     raise ExceptionGroup("there were problems", excs)
 
 
-try:
+try:  # [using-exception-groups-in-unsupported-version]
     f()
 except* OSError as e:
     print("There were OSErrors")

--- a/doc/data/messages/u/using-exception-groups-in-unsupported-version/details.rst
+++ b/doc/data/messages/u/using-exception-groups-in-unsupported-version/details.rst
@@ -1,0 +1,1 @@
+Exception groups were introduced in Python 3.11; to use it, please use a more recent version of Python.

--- a/doc/data/messages/u/using-exception-groups-in-unsupported-version/good.py
+++ b/doc/data/messages/u/using-exception-groups-in-unsupported-version/good.py
@@ -1,0 +1,10 @@
+def f():
+    raise OSError("error 1")
+
+
+try:
+    f()
+except OSError as e:
+    print("There were OSErrors")
+except SystemError as e:
+    print("There were SystemErrors")

--- a/doc/data/messages/u/using-exception-groups-in-unsupported-version/pylintrc
+++ b/doc/data/messages/u/using-exception-groups-in-unsupported-version/pylintrc
@@ -1,0 +1,2 @@
+[main]
+py-version=3.10

--- a/doc/data/messages/u/using-generic-type-syntax-in-unsupported-version/bad.py
+++ b/doc/data/messages/u/using-generic-type-syntax-in-unsupported-version/bad.py
@@ -1,1 +1,1 @@
-type VectorT = list[float]
+type VectorT = list[float]  # [using-generic-type-syntax-in-unsupported-version]

--- a/doc/data/messages/u/using-generic-type-syntax-in-unsupported-version/bad.py
+++ b/doc/data/messages/u/using-generic-type-syntax-in-unsupported-version/bad.py
@@ -1,1 +1,1 @@
-type VectorT = list[float]  # [using-generic-type-syntax-in-unsupported-version]
+type Vector = list[float]  # [using-generic-type-syntax-in-unsupported-version]

--- a/doc/data/messages/u/using-generic-type-syntax-in-unsupported-version/bad.py
+++ b/doc/data/messages/u/using-generic-type-syntax-in-unsupported-version/bad.py
@@ -1,0 +1,1 @@
+type VectorT = list[float]

--- a/doc/data/messages/u/using-generic-type-syntax-in-unsupported-version/details.rst
+++ b/doc/data/messages/u/using-generic-type-syntax-in-unsupported-version/details.rst
@@ -1,0 +1,1 @@
+Generic type syntax was introduced in Python 3.12; to use it, please use a more recent version of Python.

--- a/doc/data/messages/u/using-generic-type-syntax-in-unsupported-version/good.py
+++ b/doc/data/messages/u/using-generic-type-syntax-in-unsupported-version/good.py
@@ -1,3 +1,3 @@
 from typing import TypeAlias
 
-VectorT: TypeAlias = list[float]
+Vector: TypeAlias = list[float]

--- a/doc/data/messages/u/using-generic-type-syntax-in-unsupported-version/good.py
+++ b/doc/data/messages/u/using-generic-type-syntax-in-unsupported-version/good.py
@@ -1,0 +1,3 @@
+from typing import TypeAlias
+
+VectorT: TypeAlias = list[float]

--- a/doc/data/messages/u/using-generic-type-syntax-in-unsupported-version/pylintrc
+++ b/doc/data/messages/u/using-generic-type-syntax-in-unsupported-version/pylintrc
@@ -1,0 +1,2 @@
+[main]
+py-version=3.11

--- a/doc/user_guide/checkers/features.rst
+++ b/doc/user_guide/checkers/features.rst
@@ -1351,9 +1351,15 @@ Verbatim name of the checker is ``unsupported_version``.
 
 Unsupported Version checker Messages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+:using-exception-groups-in-unsupported-version (W2603): *Exception groups are not supported by all versions included in the py-version setting*
+  Used when the py-version set by the user is lower than 3.11 and pylint
+  encounters ``except*`` or `ExceptionGroup``.
 :using-f-string-in-unsupported-version (W2601): *F-strings are not supported by all versions included in the py-version setting*
   Used when the py-version set by the user is lower than 3.6 and pylint
   encounters an f-string.
+:using-generic-type-syntax-in-unsupported-version (W2604): *Generic type syntax (PEP 695) is not supported by all versions included in the py-version setting*
+  Used when the py-version set by the user is lower than 3.12 and pylint
+  encounters generic type syntax.
 :using-final-decorator-in-unsupported-version (W2602): *typing.final is not supported by all versions included in the py-version setting*
   Used when the py-version set by the user is lower than 3.8 and pylint
   encounters a ``typing.final`` decorator.

--- a/doc/user_guide/messages/messages_overview.rst
+++ b/doc/user_guide/messages/messages_overview.rst
@@ -349,8 +349,10 @@ All messages in the warning category:
    warning/useless-type-doc
    warning/useless-with-lock
    warning/using-constant-test
+   warning/using-exception-groups-in-unsupported-version
    warning/using-f-string-in-unsupported-version
    warning/using-final-decorator-in-unsupported-version
+   warning/using-generic-type-syntax-in-unsupported-version
    warning/while-used
    warning/wildcard-import
    warning/wrong-exception-operation

--- a/doc/whatsnew/fragments/9791.new_check
+++ b/doc/whatsnew/fragments/9791.new_check
@@ -1,0 +1,5 @@
+Add `using-exception-group-in-unsupported-version` and
+`using-generic-type-syntax-in-unsupported-version` for uses of Python 3.11+ or
+3.12+ features on lower supported versions provided with `--py-version`.
+
+Closes #9791

--- a/pylint/checkers/unsupported_version.py
+++ b/pylint/checkers/unsupported_version.py
@@ -46,13 +46,13 @@ class UnsupportedVersionChecker(BaseChecker):
             "Exception groups are not supported by all versions included in the py-version setting",
             "using-exception-groups-in-unsupported-version",
             "Used when the py-version set by the user is lower than 3.11 and pylint encounters "
-            "``except*`` or ``except ExceptionGroup``.",
+            "``except*`` or `ExceptionGroup``.",
         ),
         "W2604": (
             "Generic type syntax (PEP 695) is not supported by all versions included in the py-version setting",
             "using-generic-type-syntax-in-unsupported-version",
             "Used when the py-version set by the user is lower than 3.11 and pylint encounters "
-            "``except*`` or ``except ExceptionGroup``.",
+            "generic type syntax.",
         ),
     }
 

--- a/pylint/checkers/unsupported_version.py
+++ b/pylint/checkers/unsupported_version.py
@@ -51,7 +51,7 @@ class UnsupportedVersionChecker(BaseChecker):
         "W2604": (
             "Generic type syntax (PEP 695) is not supported by all versions included in the py-version setting",
             "using-generic-type-syntax-in-unsupported-version",
-            "Used when the py-version set by the user is lower than 3.11 and pylint encounters "
+            "Used when the py-version set by the user is lower than 3.12 and pylint encounters "
             "generic type syntax.",
         ),
     }

--- a/tests/functional/u/unsupported/unsupported_version_for_exception_group.py
+++ b/tests/functional/u/unsupported/unsupported_version_for_exception_group.py
@@ -1,0 +1,13 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring
+def f():
+    excs = [OSError("error 1"), SystemError("error 2")]
+    # +1: [using-exception-groups-in-unsupported-version]
+    raise ExceptionGroup("there were problems", excs)
+
+
+try:  # [using-exception-groups-in-unsupported-version]
+    f()
+except* OSError as e:
+    print("There were OSErrors")
+except* SystemError as e:
+    print("There were SystemErrors")

--- a/tests/functional/u/unsupported/unsupported_version_for_exception_group.py
+++ b/tests/functional/u/unsupported/unsupported_version_for_exception_group.py
@@ -11,3 +11,11 @@ except* OSError as e:
     print("There were OSErrors")
 except* SystemError as e:
     print("There were SystemErrors")
+
+
+try:
+    f()
+except ExceptionGroup as group:  # [using-exception-groups-in-unsupported-version]
+    # https://github.com/pylint-dev/pylint/issues/8985
+    for exc in group.exceptions:  # pylint: disable=not-an-iterable
+        print("ERROR: ", exc)

--- a/tests/functional/u/unsupported/unsupported_version_for_exception_group.rc
+++ b/tests/functional/u/unsupported/unsupported_version_for_exception_group.rc
@@ -1,0 +1,5 @@
+[main]
+py-version=3.10
+
+[testoptions]
+min_pyver=3.11

--- a/tests/functional/u/unsupported/unsupported_version_for_exception_group.txt
+++ b/tests/functional/u/unsupported/unsupported_version_for_exception_group.txt
@@ -1,0 +1,2 @@
+using-exception-groups-in-unsupported-version:5:4:5:53:f:Exception groups are not supported by all versions included in the py-version setting:UNDEFINED
+using-exception-groups-in-unsupported-version:8:0:13:36::Exception groups are not supported by all versions included in the py-version setting:UNDEFINED

--- a/tests/functional/u/unsupported/unsupported_version_for_exception_group.txt
+++ b/tests/functional/u/unsupported/unsupported_version_for_exception_group.txt
@@ -1,2 +1,3 @@
 using-exception-groups-in-unsupported-version:5:4:5:53:f:Exception groups are not supported by all versions included in the py-version setting:UNDEFINED
 using-exception-groups-in-unsupported-version:8:0:13:36::Exception groups are not supported by all versions included in the py-version setting:UNDEFINED
+using-exception-groups-in-unsupported-version:18:0:21:29::Exception groups are not supported by all versions included in the py-version setting:UNDEFINED

--- a/tests/functional/u/unsupported/unsupported_version_for_generic_type_syntax.py
+++ b/tests/functional/u/unsupported/unsupported_version_for_generic_type_syntax.py
@@ -1,4 +1,5 @@
 # pylint: disable=missing-function-docstring, missing-module-docstring, line-too-long
-type Vector = list[float]  # [using-generic-type-syntax-in-unsupported-version]
+# +1: [using-generic-type-syntax-in-unsupported-version, using-generic-type-syntax-in-unsupported-version]
+type Point[T] = tuple[float, float]
 # +1: [using-generic-type-syntax-in-unsupported-version, using-generic-type-syntax-in-unsupported-version]
 type Alias[*Ts] = tuple[*Ts]

--- a/tests/functional/u/unsupported/unsupported_version_for_generic_type_syntax.py
+++ b/tests/functional/u/unsupported/unsupported_version_for_generic_type_syntax.py
@@ -1,0 +1,4 @@
+# pylint: disable=missing-function-docstring, missing-module-docstring, line-too-long
+type Vector = list[float]  # [using-generic-type-syntax-in-unsupported-version]
+# +1: [using-generic-type-syntax-in-unsupported-version, using-generic-type-syntax-in-unsupported-version]
+type Alias[*Ts] = tuple[*Ts]

--- a/tests/functional/u/unsupported/unsupported_version_for_generic_type_syntax.rc
+++ b/tests/functional/u/unsupported/unsupported_version_for_generic_type_syntax.rc
@@ -1,0 +1,5 @@
+[main]
+py-version=3.11
+
+[testoptions]
+min_pyver=3.12

--- a/tests/functional/u/unsupported/unsupported_version_for_generic_type_syntax.txt
+++ b/tests/functional/u/unsupported/unsupported_version_for_generic_type_syntax.txt
@@ -1,0 +1,3 @@
+using-generic-type-syntax-in-unsupported-version:2:0:2:25::Generic type syntax (PEP 695) is not supported by all versions included in the py-version setting:UNDEFINED
+using-generic-type-syntax-in-unsupported-version:4:0:4:28::Generic type syntax (PEP 695) is not supported by all versions included in the py-version setting:UNDEFINED
+using-generic-type-syntax-in-unsupported-version:4:11:4:14::Generic type syntax (PEP 695) is not supported by all versions included in the py-version setting:UNDEFINED

--- a/tests/functional/u/unsupported/unsupported_version_for_generic_type_syntax.txt
+++ b/tests/functional/u/unsupported/unsupported_version_for_generic_type_syntax.txt
@@ -1,3 +1,4 @@
-using-generic-type-syntax-in-unsupported-version:2:0:2:25::Generic type syntax (PEP 695) is not supported by all versions included in the py-version setting:UNDEFINED
-using-generic-type-syntax-in-unsupported-version:4:0:4:28::Generic type syntax (PEP 695) is not supported by all versions included in the py-version setting:UNDEFINED
-using-generic-type-syntax-in-unsupported-version:4:11:4:14::Generic type syntax (PEP 695) is not supported by all versions included in the py-version setting:UNDEFINED
+using-generic-type-syntax-in-unsupported-version:3:0:3:35::Generic type syntax (PEP 695) is not supported by all versions included in the py-version setting:UNDEFINED
+using-generic-type-syntax-in-unsupported-version:3:11:3:12::Generic type syntax (PEP 695) is not supported by all versions included in the py-version setting:UNDEFINED
+using-generic-type-syntax-in-unsupported-version:5:0:5:28::Generic type syntax (PEP 695) is not supported by all versions included in the py-version setting:UNDEFINED
+using-generic-type-syntax-in-unsupported-version:5:11:5:14::Generic type syntax (PEP 695) is not supported by all versions included in the py-version setting:UNDEFINED


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pylint-dev/pylint#9792](https://togithub.com/pylint-dev/pylint/pull/9792).



The original branch is upstream/unsupported-311-312-features