### PR TITLE
Update setuptools to >=71.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=66.1"]
+requires = ["setuptools>=71.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=71.0.1"]
+requires = ["setuptools>=71.0.4"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -9,4 +9,4 @@ pytest-timeout~=2.3
 towncrier~=23.11
 requests
 # Voluntary for test purpose, not actually used in prod, see #8904
-setuptools>=71.0.1;python_version>='3.12'
+setuptools;python_version>='3.12'

--- a/requirements_test_min.txt
+++ b/requirements_test_min.txt
@@ -9,4 +9,4 @@ pytest-timeout~=2.3
 towncrier~=23.11
 requests
 # Voluntary for test purpose, not actually used in prod, see #8904
-setuptools==41.6.0
+setuptools>=71.0.1;python_version>='3.12'

--- a/tests/functional/r/recursion/recursion_error_3159.py
+++ b/tests/functional/r/recursion/recursion_error_3159.py
@@ -13,8 +13,7 @@ class AnyCommand(Command):
     def finalize_options(self):
         pass
 
-    @staticmethod
-    def run():
+    def run(self):
         print("Do anything")
 
 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pylint-dev/pylint#9812](https://togithub.com/pylint-dev/pylint/pull/9812).



The original branch is fork-9812-cdce8p/fix-setuptools