### PR TITLE
Fix a crash when a subclass extends `__slots__`

### DIFF
--- a/doc/whatsnew/fragments/9814.bugfix
+++ b/doc/whatsnew/fragments/9814.bugfix
@@ -1,0 +1,3 @@
+Fix a crash when a subclass extends ``__slots__``.
+
+Closes #9814

--- a/pylint/checkers/classes/class_checker.py
+++ b/pylint/checkers/classes/class_checker.py
@@ -1537,7 +1537,11 @@ a metaclass class method.",
         if "__slots__" not in node.locals:
             return False
 
-        for slots in node.ilookup("__slots__"):
+        try:
+            inferred_slots = tuple(node.ilookup("__slots__"))
+        except astroid.InferenceError:
+            return False
+        for slots in inferred_slots:
             # check if __slots__ is a valid type
             if isinstance(slots, util.UninferableBase):
                 return False
@@ -1555,7 +1559,11 @@ a metaclass class method.",
         if "__slots__" not in node.locals:
             return
 
-        for slots in node.ilookup("__slots__"):
+        try:
+            inferred_slots = tuple(node.ilookup("__slots__"))
+        except astroid.InferenceError:
+            return
+        for slots in inferred_slots:
             # check if __slots__ is a valid type
             if isinstance(slots, util.UninferableBase):
                 continue
@@ -1586,8 +1594,12 @@ a metaclass class method.",
 
     def _get_classdef_slots_names(self, node: nodes.ClassDef) -> list[str]:
 
-        slots_names = []
-        for slots in node.ilookup("__slots__"):
+        slots_names: list[str] = []
+        try:
+            inferred_slots = tuple(node.ilookup("__slots__"))
+        except astroid.InferenceError:  # pragma: no cover
+            return slots_names
+        for slots in inferred_slots:
             if isinstance(slots, nodes.Dict):
                 values = [item[0] for item in slots.items]
             else:

--- a/tests/functional/s/slots_checks.py
+++ b/tests/functional/s/slots_checks.py
@@ -187,3 +187,17 @@ class ClassWithEmptySlotsAndAnnotation:
     __slots__ = ()
 
     a: int
+
+
+# https://github.com/pylint-dev/pylint/issues/9814
+class SlotsManipulationTest:
+    __slots__ = ["a", "b", "c"]
+
+
+class TestChild(SlotsManipulationTest):
+    __slots__ += ["d", "e", "f"]  # pylint: disable=undefined-variable
+
+
+t = TestChild()
+
+print(t.__slots__)


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [pylint-dev/pylint#9817](https://togithub.com/pylint-dev/pylint/pull/9817).



The original branch is upstream/jtw/fix-slots-crash